### PR TITLE
Use Travis to build rpms, upload to Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ script:
   - docker cp "builder:/build/Packages/RPM/RPMS/x86_64" "./packages"
 
 after_success: |
+  version=$(grep elements_project CMakeLists.txt | sed 's/.*(//' | sed 's/[^ ]* //' | sed 's/ .*//')
   cd packages
   if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] && [ ! -z "${BINTRAY_REPO}" ]; then
     case "${TRAVIS_BRANCH}" in
       develop|master)
         for p in *.rpm; do
-          curl -T "${p}" "-u${BINTRAY_USER}:${BINTRAY_TOKEN}" "${BINTRAY_REPO}/${OS_TYPE}/${TRAVIS_BRANCH}/${OS_VERSION}/${OS_ARCH}/rpms/${p};bt_package=Elements?override=1&publish=1"
+          curl -T "${p}" "-u${BINTRAY_USER}:${BINTRAY_TOKEN}" "${BINTRAY_REPO}/${OS_TYPE}/${TRAVIS_BRANCH}/${OS_VERSION}/${OS_ARCH}/rpms/${p};bt_package=Elements;bt_version=${version}?override=1&publish=1"
         done;;
     esac
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,32 @@
-language: cpp
-
-dist: xenial
+language: minimal
 
 env:
-  - VERBOSE=1 CTEST_OUTPUT_ON_FAILURE=1
+  global:
+    - BINTRAY_REPO="https://api.bintray.com/content/astrorama/"
+    - OS_ARCH=x86_64
+  matrix:
+    - OS_TYPE=fedora OS_VERSION=29
+    - OS_TYPE=fedora OS_VERSION=30
+    - OS_TYPE=fedora OS_VERSION=31
+    - OS_TYPE=fedora OS_VERSION=rawhide
 
-before_install:
-  - sudo apt-get install -y libboost-all-dev python-pytest liblog4cpp5-dev doxygen libccfits-dev
-  - sudo apt-get install graphviz
-  - sudo apt-get install sphinx-common python-sphinx
+services:
+  - docker
 
-compiler:
-  - gcc
-#  - clang
+install: true
 
-before_script:
-  - mkdir build
-  - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+script:
+  - docker run --name builder --volume "$(pwd):/src" "${OS_TYPE}:${OS_VERSION}" bash "/src/.travis/build-rpm.sh"
+  - docker cp "builder:/build/Packages/RPM/RPMS/x86_64" "./packages"
 
-script: 
-  - make 
-  - sudo make install 
-  - make test 
-  - make doc
+after_success: |
+  cd packages
+  if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+    case "${TRAVIS_BRANCH}" in
+      develop|master)
+        for p in *.rpm; do
+          curl -T "${p}" "-u${BINTRAY_USER}:${BINTRAY_TOKEN}" "${BINTRAY_REPO}/${OS_TYPE}/${TRAVIS_BRANCH}/${OS_VERSION}/${OS_ARCH}/rpms/${p};bt_package=Elements?override=1&publish=1"
+        done;;
+    esac
+  fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - OS_TYPE=fedora OS_VERSION=29
     - OS_TYPE=fedora OS_VERSION=30
     - OS_TYPE=fedora OS_VERSION=31
-    - OS_TYPE=fedora OS_VERSION=rawhide
+    - OS_TYPE=fedora OS_VERSION=32
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: minimal
 
 env:
   global:
-    - BINTRAY_REPO="https://api.bintray.com/content/astrorama/"
     - OS_ARCH=x86_64
   matrix:
     - OS_TYPE=fedora OS_VERSION=29
@@ -21,7 +20,7 @@ script:
 
 after_success: |
   cd packages
-  if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+  if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ] && [ ! -z "${BINTRAY_REPO}" ]; then
     case "${TRAVIS_BRANCH}" in
       develop|master)
         for p in *.rpm; do

--- a/.travis/build-rpm.sh
+++ b/.travis/build-rpm.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+
+# Environment
+export VERBOSE=1
+export CTEST_OUTPUT_ON_FAILURE=1
+
+# Platform-specific configuration
+source /etc/os-release
+
+CMAKEFLAGS="-DINSTALL_DOC=ON"
+
+if [ $NAME == 'Fedora' ] && [ $VERSION_ID -ge 30 ]; then
+  PYTHON="python3"
+  CMAKEFLAGS="$CMAKEFLAGS -DPYTHON_EXPLICIT_VERSION=3"
+else
+  PYTHON="python"
+fi
+
+# Dependencies
+yum install -y @development-tools cmake gcc-c++ rpm-build
+yum install -y boost-devel $PYTHON-pytest log4cpp-devel doxygen CCfits-devel
+yum install -y graphviz $PYTHON-sphinx $PYTHON-sphinxcontrib-apidoc
+
+# Build
+mkdir -p /build
+cd /build
+cmake -DCMAKE_INSTALL_PREFIX=/usr $CMAKEFLAGS /src
+make $MAKEFLAGS rpm
+


### PR DESCRIPTION
You can see in [Travis](https://travis-ci.org/ayllon/Elements/builds/588924616) a build of Elements that pushes the rpms to a repository in [Bintray](https://dl.bintray.com/astrorama/fedora/).

The destination paths look like:

https://dl.bintray.com/astrorama/fedora/(master|develop)/(fedora_version)/x86_64/rpms

i.e

https://dl.bintray.com/astrorama/fedora/develop/31/x86_64/rpms/Elements-5.9-1.fc31.x86_64.rpm

A repo file like this can be used:

```ini
[bintray--astrorama-fedora]
name=bintray--astrorama-fedora
baseurl=https://dl.bintray.com/astrorama/fedora/master/$releasever/$basearch
gpgcheck=0
repo_gpgcheck=0
enabled=1
```

I have made sure that these repos can be used to build dependent projects, as [Alexandria](https://travis-ci.org/ayllon/Alexandria/builds/588928519)

For forks that are not configured in Travis, the build will still happen, but the rpms will not be uploaded anywhere (script checks if `BINTRAY_REPO` is set)