### PR TITLE
Option to generate shared libraries with soname

### DIFF
--- a/cmake/ElementsBuildFlags.cmake
+++ b/cmake/ElementsBuildFlags.cmake
@@ -173,6 +173,10 @@ option(USE_LOCAL_INSTALLAREA
        "Use local InstallArea for the Developers"
        OFF)
 
+option(USE_VERSIONED_LIBRARIES
+       "Generate versioned shared libraries"
+       OFF)
+
 option(OPT_DEBUG
        "Enable optimisation for the Debug version"
        ON)

--- a/cmake/ElementsProjectConfig.cmake
+++ b/cmake/ElementsProjectConfig.cmake
@@ -2473,6 +2473,13 @@ Provide source files and the NO_PUBLIC_HEADERS option for a plugin/module librar
   string(TOLOWER ${CMAKE_BUILD_TYPE} lower_cmake_build_type)
   set_property(GLOBAL APPEND PROPERTY REGULAR_CMAKE_OBJECTS ${CMAKE_PROJECT_NAME}Exports-${lower_cmake_build_type}.cmake)
 
+  # Versioned shared libraries
+  if(USE_VERSIONED_LIBRARIES)
+    set_target_properties(${library} PROPERTIES
+      SOVERSION ${CMAKE_PROJECT_VERSION}
+    )
+  endif()
+
 endfunction()
 
 # Backward compatibility macro


### PR DESCRIPTION
Required by Fedora.
The default is OFF, so it keeps the current behaviour.