### PR TITLE
__linux macro is deprecated

### DIFF
--- a/ElementsKernel/ElementsKernel/System.h
+++ b/ElementsKernel/ElementsKernel/System.h
@@ -99,7 +99,7 @@ const std::string DEFAULT_INSTALL_PREFIX { "/usr" };
 # endif
 #endif
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__)
 #define TEMPLATE_SPECIALIZATION
 #endif
 

--- a/ElementsKernel/src/Lib/System.cpp
+++ b/ElementsKernel/src/Lib/System.cpp
@@ -124,7 +124,7 @@ unsigned long unloadDynamicLib(ImageHandle handle) {
 /// Get a specific function defined in the DLL
 unsigned long getProcedureByName(ImageHandle handle, const string& name,
     EntryPoint* pFunction) {
-#if defined(__linux)
+#if defined(__linux__)
   *pFunction = FuncPtrCast<EntryPoint>(::dlsym(handle, name.c_str()));
   if (0 == *pFunction) {
     errno = static_cast<int>(0xAFFEDEAD);


### PR DESCRIPTION
Apparently... I found this while compiling for epel7, which supports ppc64le, and there `__linux` is not defined.

See:

* [Bug 28314 - cpp: x86/powerpc inconsistency for the __linux macro ](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=28314)
* [Pre-defined Compiler Macros](https://sourceforge.net/p/predef/wiki/OperatingSystems/)

So it is a bug, not fixed in rhel7, but in any case it is a deprecated macro.