### PR TITLE
Update dependencies.txt to include python3-dnf for fedora 41

### DIFF
--- a/.github/workflows/dependencies.txt
+++ b/.github/workflows/dependencies.txt
@@ -5,6 +5,7 @@ $PYTHON-numpy
 $PYTHON-pytest
 $PYTHON-sphinx
 $PYTHON-lxml
+$PYTHON-dnf
 CCfits-devel
 $BOOST-$PYTHON-devel
 $BOOST-devel


### PR DESCRIPTION
I think the dependency is all that is needed for fedora-41?