### PR TITLE
Apply fix for fedora41 dnf to release 6.3

### DIFF
--- a/.github/workflows/dependencies.txt
+++ b/.github/workflows/dependencies.txt
@@ -4,6 +4,7 @@ $PYTHON-setuptools
 $PYTHON-numpy
 $PYTHON-pytest
 $PYTHON-sphinx
+$PYTHON-dnf
 CCfits-devel
 $BOOST-$PYTHON-devel
 $BOOST-devel


### PR DESCRIPTION
@degauden I need to have a working rpm of fedora 6.3.2 or 6.3.3 if you prefer to call it that that works in fedora 41 so I can build sx++ for fedora 41. This is the same as #9 that was applied to develop.
