### PR TITLE
Update setup-dependencies action to 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         id: package-version
         uses: astrorama/actions/elements-project@v3.4
       - name: Install dependencies
-        uses: astrorama/actions/setup-dependencies@v3.4
+        uses: astrorama/actions/setup-dependencies@v3.7
         with:
           dependency-list: .github/workflows/dependencies.txt
       - name: Build


### PR DESCRIPTION
Fedora 42 no longer has awk by default and it's used by the setup-dependencies script. This updates the script to install it.

@degauden if you could please make a 6.3.4 release with this change when possible, this would allow us to build for Fedora 42